### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/shipjs-manual-prepare.yml
+++ b/.github/workflows/shipjs-manual-prepare.yml
@@ -8,6 +8,8 @@ jobs:
       github.event_name == 'issue_comment' &&
       (github.event.comment.author_association == 'member' || github.event.comment.author_association == 'owner') &&
       startsWith(github.event.comment.body, '@shipjs prepare')
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,6 +32,9 @@ jobs:
 
   create_done_comment:
     if: success()
+    permissions:
+      contents: read
+      issues: write
     needs: manual_prepare
     runs-on: ubuntu-latest
     steps:
@@ -46,6 +51,9 @@ jobs:
 
   create_fail_comment:
     if: cancelled() || failure()
+    permissions:
+      contents: read
+      issues: write
     needs: manual_prepare
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/deadjdona/search-insights-gtm-up/security/code-scanning/6](https://github.com/deadjdona/search-insights-gtm-up/security/code-scanning/6)

In general, the fix is to add one or more `permissions:` blocks specifying the least privileges needed, instead of relying on the default `GITHUB_TOKEN` permissions. For this workflow, we should (1) set read-only repo access for the `manual_prepare` job plus whatever write scopes it actually needs (almost certainly `contents: write` for release operations), and (2) set `issues: write` (and optionally `contents: read`) for the two comment-creation jobs, since they only need to post issue comments.

The single best way to fix this without altering behavior is to add per-job `permissions:` blocks under `manual_prepare`, `create_done_comment`, and `create_fail_comment`. That keeps scopes tight and clearly documents what each job needs. Concretely:
- For `manual_prepare`, add:
  ```yaml
  permissions:
    contents: write
  ```
  underneath the `if:` condition and before `runs-on:`. This allows pushing tags/commits if the release step uses `GITHUB_TOKEN` implicitly anywhere, while not granting broader scopes.
- For `create_done_comment` and `create_fail_comment`, add:
  ```yaml
  permissions:
    contents: read
    issues: write
  ```
  under each job’s `if:` line and before `needs:`/`runs-on:`. These jobs only need to read basic repo metadata and write comments.

No new imports or external libraries are involved because this is a YAML workflow change only. All changes are within `.github/workflows/shipjs-manual-prepare.yml` at the shown regions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
